### PR TITLE
Verify endpoint certificates by default

### DIFF
--- a/rgw_admin/__init__.py
+++ b/rgw_admin/__init__.py
@@ -41,11 +41,12 @@ class HttpError(Exception):
 
 
 class AdminClient:
-    def __init__(self, url, access_key, secret_key):
+    def __init__(self, url, access_key, secret_key, verify_cert=True):
         self._url = url
         self._auth = S3Auth(access_key, secret_key)
         self._access_key = access_key
         self._secret_key = secret_key
+        self._verify_cert = verify_cert
 
     def _request(self, method, path, schema=None, *, params=None, data=None):
         url = urljoin(self._url, path)
@@ -55,7 +56,7 @@ class AdminClient:
             auth=self._auth,
             params=params,
             data=data,
-            verify=False
+            verify=self._verify_cert
         )
 
         if response.status_code >= 400:


### PR DESCRIPTION
Add a parameter to AdminClient to set certificate verification. This
should be always enabled! If using a private CA, either instantiate the
AdminClient with the path to the certificate or use the
REQUESTS_CA_BUNDLE environment variable.

It's annoying that requests does not use the system CA store, but this
is a whole other issue.